### PR TITLE
Unix epoch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
 python:
+  - pypy
+  - pypy3
   - 2.7
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
 install:
   - pip install coveralls tox-travis
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - pypy
-  - pypy3
+  - pypy3.3-5.2-alpha1
   - 2.7
   - 3.3
   - 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
 language: python
-python: 3.5
-env:
-  # Avoid testing pypy on travis until the following issue is fixed:
-  #   https://github.com/travis-ci/travis-ci/issues/4756
-  #- TOX_ENV=pypy
-  - TOX_ENV=py35
-  - TOX_ENV=py34
-  - TOX_ENV=py33
-  - TOX_ENV=py32
-  - TOX_ENV=py27
-  - TOX_ENV=py26
+python:
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
 install:
-  - pip install coveralls tox
-script: tox -e  $TOX_ENV
+  - pip install coveralls tox-travis
+script: tox
 after_success: coveralls

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-arrow>=0.4,<0.8
-requests>=2.5,<2.9
-requests-oauth>=0.4.1,<0.5
-requests-oauthlib>=0.4.2,<0.6
+arrow>=0.4
+requests>=2.5
+requests-oauth>=0.4.1
+requests-oauthlib>=0.4.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 -r base.txt
 
-coverage>=3.7,<4.0
-mock>=1.0,<1.4
-tox>=1.8,<2.2
+coverage>=3.7
+mock>=1.0
+tox>=1.8

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,14 @@ setup(
         "Intended Audience :: Developers",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation",
-        "Programming Language :: Python :: Implementation :: PyPy"
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ]
 )

--- a/tests/test_withings_api.py
+++ b/tests/test_withings_api.py
@@ -1,8 +1,6 @@
 import json
-import time
 import unittest
 
-from datetime import datetime
 from requests import Session
 from withings import (
     WithingsActivity,
@@ -31,7 +29,7 @@ class TestWithingsApi(unittest.TestCase):
         if self.mock_api:
             self.creds = WithingsCredentials()
         else:
-            config = ConfigParser.ConfigParser()
+            config = configparser.ConfigParser()
             config.read('withings.conf')
             self.creds = WithingsCredentials(
                 consumer_key=config.get('withings', 'consumer_key'),
@@ -145,7 +143,6 @@ class TestWithingsApi(unittest.TestCase):
         self.assertEqual(resp.series[0].enddate.timestamp,
                          body['series'][0]['enddate'])
         self.assertEqual(resp.series[1].state, 1)
-
 
     def test_get_activities(self):
         """
@@ -288,7 +285,6 @@ class TestWithingsApi(unittest.TestCase):
                     'callbackurl': 'http://www.example.com/'})
         self.assertEqual(resp, None)
 
-
     def test_is_subscribed(self):
         """
         Check that is_subscribed fetches the right URL and returns the
@@ -340,7 +336,7 @@ class TestWithingsApi(unittest.TestCase):
     def mock_request(self, body, status=0):
         if self.mock_api:
             json_content = {'status': status}
-            if body != None:
+            if body is not None:
                 json_content['body'] = body
             response = MagicMock()
             response.content = json.dumps(json_content).encode('utf8')

--- a/tests/test_withings_api.py
+++ b/tests/test_withings_api.py
@@ -1,3 +1,5 @@
+import arrow
+import datetime
 import json
 import unittest
 
@@ -236,6 +238,36 @@ class TestWithingsApi(unittest.TestCase):
             params={'action': 'getmeas', 'limit': 1})
         self.assertEqual(len(resp), 1)
         self.assertEqual(resp[0].weight, 86.0)
+
+    def test_get_measures_lastupdate_date(self):
+        """Check that dates get converted to timestampse for API calls"""
+        self.mock_request({'updatetime': 1409596058, 'measuregrps': []})
+
+        self.api.get_measures(lastupdate=datetime.date(2014, 9, 1))
+
+        Session.request.assert_called_once_with(
+            'GET', 'http://wbsapi.withings.net/measure',
+            params={'action': 'getmeas', 'lastupdate': 1409529600})
+
+    def test_get_measures_lastupdate_datetime(self):
+        """Check that datetimes get converted to timestampse for API calls"""
+        self.mock_request({'updatetime': 1409596058, 'measuregrps': []})
+
+        self.api.get_measures(lastupdate=datetime.datetime(2014, 9, 1))
+
+        Session.request.assert_called_once_with(
+            'GET', 'http://wbsapi.withings.net/measure',
+            params={'action': 'getmeas', 'lastupdate': 1409529600})
+
+    def test_get_measures_lastupdate_arrow(self):
+        """Check that arrow dates get converted to timestampse for API calls"""
+        self.mock_request({'updatetime': 1409596058, 'measuregrps': []})
+
+        self.api.get_measures(lastupdate=arrow.get('2014-09-01'))
+
+        Session.request.assert_called_once_with(
+            'GET', 'http://wbsapi.withings.net/measure',
+            params={'action': 'getmeas', 'lastupdate': 1409529600})
 
     def test_subscribe(self):
         """

--- a/tests/test_withings_measures.py
+++ b/tests/test_withings_measures.py
@@ -1,7 +1,7 @@
-import time
 import unittest
 
 from withings import WithingsMeasureGroup, WithingsMeasures
+
 
 class TestWithingsMeasures(unittest.TestCase):
     def test_withings_measures_init(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,6 @@
 [tox]
-envlist = pypy,py35,py34,py33,py32,py27,py26
+envlist = pypy,pypy3,py36,py35,py34,py33,py27
 
 [testenv]
 commands = coverage run --branch --source=withings setup.py test
 deps = -r{toxinidir}/requirements/test.txt
-
-[testenv:pypy]
-basepython = pypy
-
-[testenv:py35]
-basepython = python3.5
-
-[testenv:py34]
-basepython = python3.4
-
-[testenv:py33]
-basepython = python3.3
-
-[testenv:py32]
-basepython = python3.2
-
-[testenv:py27]
-basepython = python2.7
-
-[testenv:py26]
-basepython = python2.6

--- a/withings/__init__.py
+++ b/withings/__init__.py
@@ -41,7 +41,6 @@ import json
 import requests
 
 from arrow.parser import ParserError
-from datetime import datetime
 from requests_oauthlib import OAuth1, OAuth1Session
 
 
@@ -82,11 +81,13 @@ class WithingsAuth(object):
                               resource_owner_secret=self.oauth_secret,
                               verifier=oauth_verifier)
         tokens = oauth.fetch_access_token('%s/access_token' % self.URL)
-        return WithingsCredentials(access_token=tokens['oauth_token'],
-                                   access_token_secret=tokens['oauth_token_secret'],
-                                   consumer_key=self.consumer_key,
-                                   consumer_secret=self.consumer_secret,
-                                   user_id=tokens['userid'])
+        return WithingsCredentials(
+            access_token=tokens['oauth_token'],
+            access_token_secret=tokens['oauth_token_secret'],
+            consumer_key=self.consumer_key,
+            consumer_secret=self.consumer_secret,
+            user_id=tokens['userid'],
+        )
 
 
 class WithingsApi(object):
@@ -173,15 +174,22 @@ class WithingsActivity(WithingsObject):
 
 class WithingsMeasures(list, WithingsObject):
     def __init__(self, data):
-        super(WithingsMeasures, self).__init__([WithingsMeasureGroup(g) for g in data['measuregrps']])
+        super(WithingsMeasures, self).__init__(
+            [WithingsMeasureGroup(g) for g in data['measuregrps']])
         self.set_attributes(data)
 
 
 class WithingsMeasureGroup(WithingsObject):
-    MEASURE_TYPES = (('weight', 1), ('height', 4), ('fat_free_mass', 5),
-                     ('fat_ratio', 6), ('fat_mass_weight', 8),
-                     ('diastolic_blood_pressure', 9), ('systolic_blood_pressure', 10),
-                     ('heart_pulse', 11))
+    MEASURE_TYPES = (
+        ('weight', 1),
+        ('height', 4),
+        ('fat_free_mass', 5),
+        ('fat_ratio', 6),
+        ('fat_mass_weight', 8),
+        ('diastolic_blood_pressure', 9),
+        ('systolic_blood_pressure', 10),
+        ('heart_pulse', 11),
+    )
 
     def __init__(self, data):
         super(WithingsMeasureGroup, self).__init__(data)


### PR DESCRIPTION
@orcasgit/orcas-developers Please review. This should fix the issue with withings notifications not getting processed. The one difference between when we get data for notifications and when we get initial data is that we add a `lastupdated` parameter when getting data for notifications. We pass a `datetime.datetime` object and I'm not entirely sure what `requests` transforms that to for the request, but according to the Withings API it needs to be a "Date in unix epoch". The `timestamp` attribute in `arrow` works well in my testing.

I'm pulling against develope because it has the latest commits, but I'm thinking after this change is done we should merge to master and publish to PyPI